### PR TITLE
Support node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
 script:
   npm test

--- a/spec/test.js
+++ b/spec/test.js
@@ -131,7 +131,9 @@ describe('allAsync passing a array with one wrong url address', function(){
 
   it('should return a rejected promise with error ENOTFOUND', function(){
     result.should.exist.and.be.a('object');
-    return result.should.eventually.be.rejected.and.have.property('message', 'getaddrinfo ENOTFOUND');
+    return result.should.eventually.be.rejected
+        .and.have.property('message')
+        .that.contain('getaddrinfo ENOTFOUND');
   });
 });
 
@@ -169,7 +171,9 @@ describe('allAsync passing a object with one wrong url address', function(){
 
   it('should return a rejected promise with error ENOTFOUND', function(){
     result.should.exist.and.be.a('object');
-    return result.should.eventually.be.rejected.and.have.property('message', 'getaddrinfo ENOTFOUND');
+    return result.should.eventually.be.rejected
+        .and.have.property('message')
+        .that.contain('getaddrinfo ENOTFOUND');
   });
 });
 


### PR DESCRIPTION
The error message of ENOTFOUND errors changed in node 0.12.

Instead of `getaddrinfo ENOTFOUND` the message now includes also the
host, e. g. `getaddrinfo ENOTFOUND googldasdadase.com`.